### PR TITLE
Potential fix for code scanning alert no. 3: DOM text reinterpreted as HTML

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "tailwindcss-animate": "^1.0.7",
     "tw-animate-css": "^1.2.5",
     "uuid": "^9.0.1",
-    "zod": "^3.24.2"
+    "zod": "^3.24.2",
+    "dompurify": "^3.2.5"
   },
   "devDependencies": {
     "@eslint/js": "^9.11.1",

--- a/src/components/ShareRecipeDialog.tsx
+++ b/src/components/ShareRecipeDialog.tsx
@@ -24,6 +24,7 @@ import {
 } from "lucide-react";
 import type { Recipe } from "@/types/recipe";
 import html2canvas from "html2canvas-pro";
+import DOMPurify from "dompurify";
 
 interface ShareRecipeDialogProps {
   recipe: Recipe;
@@ -200,7 +201,7 @@ ${recipe.instructions.map((step, i) => `${i + 1}. ${step}`).join("\n")}
     tempDiv.style.backgroundColor = "white";
     tempDiv.style.position = "absolute";
     tempDiv.style.left = "-9999px";
-    tempDiv.innerHTML = `
+    const htmlContent = `
       <div style="font-family: Arial, sans-serif;">
         <h1 style="color: #ea580c; margin-bottom: 10px;">${recipe.title}</h1>
         <div style="display: flex; margin-bottom: 10px;">
@@ -229,6 +230,7 @@ ${recipe.instructions.map((step, i) => `${i + 1}. ${step}`).join("\n")}
         </div>
       </div>
     `;
+    tempDiv.innerHTML = DOMPurify.sanitize(htmlContent);
 
     document.body.appendChild(tempDiv);
 


### PR DESCRIPTION
Potential fix for [https://github.com/sashauly/receptik/security/code-scanning/3](https://github.com/sashauly/receptik/security/code-scanning/3)

To fix this issue, we need to ensure that any user-controlled data inserted into the HTML is properly escaped to prevent XSS attacks. The best way to do this is to use a library like `DOMPurify` to sanitize the HTML content before setting it with `innerHTML`.

1. Install the `DOMPurify` library.
2. Import `DOMPurify` in the `ShareRecipeDialog` component.
3. Use `DOMPurify.sanitize` to sanitize the HTML content before setting it to `innerHTML`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
